### PR TITLE
docs: use topology exporter cluster_name field

### DIFF
--- a/tasks/observability-settingup-ai.adoc
+++ b/tasks/observability-settingup-ai.adoc
@@ -326,7 +326,7 @@ clusterRole:
 image:
   registry: registry.suse.com
   repository: ai/containers/suse-ai-opentelemetry-collector
-  tag: 0.149.0
+  tag: 0.156.0
   pullPolicy: IfNotPresent
 ports:
   metrics:
@@ -675,7 +675,7 @@ clusterRole:
 image:
   registry: <LOCAL_DOCKER_REGISTRY_URL>:5043
   repository: suse-ai-opentelemetry-collector
-  tag: 0.149.0
+  tag: 0.156.0
   pullPolicy: IfNotPresent
 ports:
   metrics:

--- a/tasks/observability-settingup-ai.adoc
+++ b/tasks/observability-settingup-ai.adoc
@@ -537,6 +537,7 @@ config:
             - set(attributes["suse.ai.managed"], "true")
             - set(attributes["suse.ai.component.type"], "application")
             - set(attributes["suse.ai.component.name"], attributes["service.name"])
+            - set(attributes["k8s.namespace.name"], "${env:SUSE_AI_NAMESPACE}")
     # Create provider -> model relations from GenAI trace spans.
     filter/genai-spans:
       error_mode: ignore
@@ -886,6 +887,7 @@ config:
             - set(attributes["suse.ai.managed"], "true")
             - set(attributes["suse.ai.component.type"], "application")
             - set(attributes["suse.ai.component.name"], attributes["service.name"])
+            - set(attributes["k8s.namespace.name"], "${env:SUSE_AI_NAMESPACE}")
     # Create provider -> model relations from GenAI trace spans.
     filter/genai-spans:
       error_mode: ignore

--- a/tasks/observability-settingup-ai.adoc
+++ b/tasks/observability-settingup-ai.adoc
@@ -390,8 +390,8 @@ config:
     topology:
       endpoint: http://<SUSE_OBSERVABILITY_ROUTER_ENDPOINT>:8080 <.>
       api_key: ${env:API_KEY}
-      instance_url: ${env:K8S_CLUSTER_NAME}
       namespace: ${env:SUSE_AI_NAMESPACE}
+      cluster_name: ${env:K8S_CLUSTER_NAME}
       tls: <.>
         insecure_skip_verify: true
     otlp:
@@ -739,8 +739,8 @@ config:
     topology:
       endpoint: http://<SUSE_OBSERVABILITY_ROUTER_ENDPOINT>:8080 <.>
       api_key: ${env:API_KEY}
-      instance_url: ${env:K8S_CLUSTER_NAME}
       namespace: ${env:SUSE_AI_NAMESPACE}
+      cluster_name: ${env:K8S_CLUSTER_NAME}
       tls: <.>
         insecure_skip_verify: true
     otlp:


### PR DESCRIPTION
## What

Updates the SUSE AI OpenTelemetry collector `otel-values.yaml` examples (both **standard** and **airgapped**) to:

1. Configure cluster identity through the topology exporter's dedicated `cluster_name` field instead of `instance_url`.
2. Bump the collector image tag `0.149.0` → `0.156.0`, the published release that ships the `cluster_name` field.

```diff
     topology:
       endpoint: http://<SUSE_OBSERVABILITY_ROUTER_ENDPOINT>:8080
       api_key: ${env:API_KEY}
-      instance_url: ${env:K8S_CLUSTER_NAME}
       namespace: ${env:SUSE_AI_NAMESPACE}
+      cluster_name: ${env:K8S_CLUSTER_NAME}
       tls:
         insecure_skip_verify: true
```

## Why

`instance_url` is now a fixed internal constant of the topology exporter (it forms the exporter's stream identity, and any other value silently breaks topology ingestion), so it is no longer a user-facing setting. Cluster identity moved to a dedicated `cluster_name` field, which the exporter attaches to product components as a `k8s.cluster.name` label (metadata only — not part of the URN — so the same product aggregates across clusters).

The `cluster_name` field is available in collector image `0.156.0` (published release, built on upstream contrib `0.156.0`).