### PR TITLE
Added the support matrix link in the document for SUSE AI Factory with NVIDIA

### DIFF
--- a/articles/ai-factory-introduction.adoc
+++ b/articles/ai-factory-introduction.adoc
@@ -65,8 +65,11 @@ endif::[]
 {productname} provides a solution that replaces manual integration of AI applications with pre-validated blueprints.
 It eliminates inconsistent "snowflake" environments and enforces governance and auditability through centralized controls.
 
+Refer to the link:https://docs.nvidia.com/ai-enterprise/support-matrix/latest/index.html[NVIDIA AI Enterprise Infrastructure Support Matrix] for compatibility details of {productname}. 
+
 Running individual AI applications often forces teams to manually stitch together multiple open-source tools using fragmented {helm} charts.
 This "do-it-yourself" approach means that teams spend excessive time on integration and maintenance rather than building AI value.
+
 
 {productname} replaces this manual burden with a digital assembly line that offers several advantages:
 

--- a/references/AI-Factory-appendix.adoc
+++ b/references/AI-Factory-appendix.adoc
@@ -39,6 +39,8 @@ Over time, new releases become generally available, new products may be added, a
 For the current lifecycle, please refer to our link:https://www.suse.com/lifecycle[Lifecycle Page].
 If you have any questions about raising a support case, how {suse} classifies severity levels, or the scope of support, see the link:https://www.suse.com/support/handbook/[Technical Support Handbook] and link:https://www.suse.com/support/policy.html[Support Policy].
 
+Refer to the link:https://docs.nvidia.com/ai-enterprise/support-matrix/latest/index.html[NVIDIA AI Enterprise Infrastructure Support Matrix] for compatibility details of {productname}. 
+
 == Obtaining source code
 
 This {suse} product includes materials licensed to {suse} under the GNU General Public License (GPL) and various other open source licenses.


### PR DESCRIPTION
Based on the request on the channel: 
https://suse.slack.com/archives/C02CQ3VTAGP/p1784030491331739

Link: https://docs.nvidia.com/ai-enterprise/support-matrix/latest/index.html

Added link in the following 2 sections: 
1. https://documentation.suse.com/suse-ai-factory/latest/html/AI-Factory-NVIDIA-introduction/id-why-use-suse-ai-factory-with-nvidia.html
2. https://documentation.suse.com/suse-ai-factory/latest/html/AI-Factory-NVIDIA-usage/ai-factory-appendix.html